### PR TITLE
Error when cloning repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ After making sure you have the necessary software, run the following commands:
 
 	# cd ~/Sites, or cd into whichever directory you store your website projects in
 	cd ~/Sites                
-	git clone git@github.com:wplib/wplib-box.git
+	git clone https://github.com/wplib/wplib-box.git
 	cd wplib-box
 	composer install
 	vagrant up


### PR DESCRIPTION
I get an error when cloning the repo with the instructions from the Quickstart.
```bash
> git clone git@github.com:wplib/wplib-box.git
Cloning into 'wplib-box'...
Permission denied (publickey).
fatal: Could not read from remote repository.
```

Maybe this has to do with my setup, but this works as it should.
```bash
git clone https://github.com/wplib/wplib-box.git
```