### PR TITLE
Windows paths and required hardware

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -123,8 +123,8 @@ Otherwise, there they are:
 - **Vagrant Box**: A `Vagrantfile` which is a specialized Ruby script that runs to download a _"Box Image"_, possibly Provisions it beyond the base box, set the local IP address for the Virtual Machine.
 - **Local Box Image Cache**: Vagrant downloads pristine copies of Box Images to a local cache to allow it to quickly copy the box to a project directory the first time `vagrant up` is run for a project, or after a `vagrant destroy` is run. Your Local Box Image Cache [is located at](http://stackoverflow.com/a/10226134/102699):
     - Mac OS X and Linux: `~/.vagrant.d/boxes`
-    - Windows: `C:/Users/{username}/.vagrant.d/boxes`
-- **Project Box Image**: Although Vagrant maintains pristine copies of Box Images in the Local Box Image Cache it makes a copy of that box for each of your projects and stores that copy in `~/VirtualBox VMs` (on Mac & Linux) and in `???` (on Windows.) It also creates a `vagrant` directory in your project to maintain information about the copy of the Box Image used by the project. For example, if you `vagrant ssh` into a running Vagrant Box and make configuration changes those changes will be in the Project's Box Image, but not in the`
+    - Windows: `C:\Users\{username}\.vagrant.d\boxes`
+- **Project Box Image**: Although Vagrant maintains pristine copies of Box Images in the Local Box Image Cache it makes a copy of that box for each of your projects and stores that copy in `~/VirtualBox VMs` (on Mac & Linux) and in `C:\Users\{username}\VirtualBox VMs` (on Windows.) It also creates a `vagrant` directory in your project to maintain information about the copy of the Box Image used by the project. For example, if you `vagrant ssh` into a running Vagrant Box and make configuration changes those changes will be in the Project's Box Image, but not in the`
 pristine copies of Box Image nor in other projects that share the same named Box Image. 
 ### Suggest a New FAQ Question & Answer
 If you have figured something out about WPLib that we have not documented, please help out your 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Windows 7 thru 10|With PowerShell or [git-bash](https://git-for-windows.github.i
 
 We assume this will work on all these platforms but we have not tested it thoroughly yet so we welcome your bug reports if you have issues with it.
 
+## Required Hardware
+
+Since WPLib Box is distributed as a virtual machine image of a 64-bit distribution of Ubuntu Linux, a 64-bit Intel or AMD CPU is required, along with support for either Intel or AMD virtualization technologies: VT-x or AMD-v. You will need to enable VT-x/AMD-v in the host PC BIOS.
+
 ## Required Software
 
 ###For Mac & Linux Users
@@ -53,6 +57,7 @@ To run WPLib Box requires the following software be installed:
 ###For Windows Users
 
 - Install everything from the Mac & Linux Users list above
+- Ensure that no other VM platform is running (either VMware or Hyper-V) as they will prevent VirtualBox from operating.
 - Install [Git](https://git-scm.com/downloads) version 2 or greater.
 - Install [PHP](http://windows.php.net/download) version 5.6 or greater.
 


### PR DESCRIPTION
This includes two changes: one nearly orphaned one from a month and a half ago clarifying the path where the box is stored on Windows.  The other is a section for required hardware to avoid support issues with older 32-bit PCs.