### PR TITLE
change the FAQ page to use the full github url, not relative

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -85,7 +85,7 @@ We can also schedule a time with you to screen share using [**ScreenHero**](http
 
 <a id="github-issues"></a>
 ### Less Urgent Help via GitHub issues
-Finally you can submit a GitHub issue with bugs and/or feature requests. Feel free to [submit any issue](/wplib/wplib-box/issues/new) about WPLib Box, especially feature requests or to discuss integrating other open-source software with the box. When you do please assign your issue the _"question"_ label. 
+Finally you can submit a GitHub issue with bugs and/or feature requests. Feel free to [submit any issue](https://github.com/wplib/wplib-box/issues/new) about WPLib Box, especially feature requests or to discuss integrating other open-source software with the box. When you do please assign your issue the _"question"_ label. 
 
 <a id="troubleshooting"></a>
 ## Troubleshooting/WPLib Box is not working


### PR DESCRIPTION
@mikeschinkel the link in the FAQ page 404's for me. PR fixes this as the url is absolute vs. relative. 

Use cases where the current link fails:
https://github.com/wplib/wplib-box/blob/master/FAQ.md
Click "submit any issue"
