### PR TITLE
VSCode Xdebug configuration update

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
             "request": "launch",
             "port": 9000,
             "localSourceRoot": "${workspaceRoot}/www",
-            "serverSourceRoot": "/projects/wplib.box/www"
+            "serverSourceRoot": "/var/www"
         },
         {
             "name": "Launch currently open script",


### PR DESCRIPTION
The VSCode Xdebug configuration needs to match the PHP-FPM path map, not the host path map.